### PR TITLE
IS34: Updating the year for the copyright to 2020

### DIFF
--- a/index.html
+++ b/index.html
@@ -454,7 +454,7 @@
             </div>
             <div class="copyright">
                 <div class="container">
-                    <p>© 2019 All Rights Reserved. Design by<a href="https://html.design/"> Free Html Templates</a></p>
+                    <p>© 2020 All Rights Reserved. Design by<a href="https://html.design/"> Free Html Templates</a></p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
The year at the bottom of the home page was 2019 and it should be 2020.

Issue ticket: https://github.com/alanboy/spicyo/issues/34